### PR TITLE
remove protocol to enable https

### DIFF
--- a/HookHead.php
+++ b/HookHead.php
@@ -25,7 +25,7 @@ class GM_head{
 					  $this->GMStyle 		= '';
 			}
 			
-		$page->head .= '<script type="text/javascript" src="http://maps.google.com/maps/api/js?key='.$this->apikey.'"></script>';
+		$page->head .= '<script type="text/javascript" src="//maps.google.com/maps/api/js?key='.$this->apikey.'"></script>';
 		$page->head .= '<script type="text/javascript" src="'.$addonRelativeCode . '/js/GM_page.js"></script>';
 		$page->css_user[] = $addonRelativeCode.'/css/maps_page.css';
 	


### PR DESCRIPTION
removing the 'http:' prefix will make the script calll adopt the page
protocol, thus it will work on http and https as well.